### PR TITLE
Replaced Font Awesome bower dependency with ember-cli-font-awesome

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,8 +12,5 @@
     "ember-qunit": "0.2.8",
     "ember-qunit-notifications": "0.0.7",
     "qunit": "~1.17.1"
-  },
-  "devDependencies": {
-    "components-font-awesome": "~4.3.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -6,11 +6,5 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
     app.import('vendor/ember-json-pretty/styles/styles.css');
-    app.import(app.bowerDirectory + '/components-font-awesome/css/font-awesome.min.css');
-    app.import(app.bowerDirectory + '/components-font-awesome/fonts/FontAwesome.otf', { destDir: 'fonts' });
-    app.import(app.bowerDirectory + '/components-font-awesome/fonts/fontawesome-webfont.eot', { destDir: 'fonts' });
-    app.import(app.bowerDirectory + '/components-font-awesome/fonts/fontawesome-webfont.svg', { destDir: 'fonts' });
-    app.import(app.bowerDirectory + '/components-font-awesome/fonts/fontawesome-webfont.ttf', { destDir: 'fonts' });
-    app.import(app.bowerDirectory + '/components-font-awesome/fonts/fontawesome-webfont.woff', { destDir: 'fonts' });
   }
 };

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config"
+  },
+  "dependencies": {
+    "ember-cli-font-awesome": "0.0.9"
   }
 }


### PR DESCRIPTION
I replaced font awesome from bower with the one provided by ember-cli-font-awesome. 