### PR TITLE
Create a demo site from the dummy site

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ember-cli-babel": "^4.0.0",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.8",
+    "ember-cli-github-pages": "0.0.6",
     "ember-cli-htmlbars": "0.7.4",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
@@ -44,7 +45,8 @@
     "pretty"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://rodrigo-morais.github.io/ember-json-pretty"
   },
   "dependencies": {
     "ember-cli-font-awesome": "0.0.9"

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy</title>
+    <title>ember-json-pretty Demo</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -43,5 +43,9 @@ module.exports = function(environment) {
 
   }
 
+  if (environment === 'gh-pages') {
+    ENV.baseURL = '/' + require('../../../package.json')['name'];
+  }
+
   return ENV;
 };


### PR DESCRIPTION
So emberaddons.com now has a demo site link and it's pretty easy to create a demo site from your ember addon's dummy folder. 

Example: http://jhr007.github.io/ember-json-pretty/
Added ember-cli-github-pages dependency
Added gh-pages environment
Updated title in index.html
Added demoURL to package.json

In clean directory, with `master` checked out run: 
```shell
npm install && bower install
git checkout --orphan gh-pages && rm -rf `ls -a | grep -vE '\.gitignore|\.git|node_modules|bower_components|(^[.]{1,2}$)'` && git add -u && git commit -m "initial gh-pages commit"
git checkout master
ember github-pages:commit --environment=gh-pages
git push origin gh-pages
```